### PR TITLE
Environment variable name bug fix and documentation clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ go get github.com/qiangxue/go-env
 
 ### Loading From Environment Variables
 
-The easiest way of using go-env is to call `env.Load()`, like the following: 
+The easiest way of using go-env is to call `env.Load()`, like the following:
 
 ```go
 package main
@@ -66,10 +66,9 @@ a struct field with an environment variable:
 - Only public struct fields will be populated
 - If the field has an `env` tag, use the tag value as the name, unless the tag value is `-` in which case it means
   the field should NOT be populated.
-- If the field has no `env` tag, turn the field name into snake format and use that as the name. For example,
-  a field name `HostName` will be turned into `Host_Name`, and `MyURL` becomes `My_URL`.
-- Names are turned into upper case and prefixed with the specified prefix when they are used to look up
-  in the environment variables.
+- If the field has no `env` tag, turn the field name into UPPER_SNAKE_CASE format and use that as the name. For example,
+  a field name `HostName` will be turned into `HOST_NAME`, and `MyURL` becomes `MY_URL`.
+- Names are prefixed with the specified prefix when they are used to look up in the environment variables.
 
 By default, prefix `APP_` will be used. You can customize the prefix by using `env.New()` to create
 a customized loader. For example,
@@ -111,7 +110,7 @@ func main() {
 ```
 
 In the above code, the `Password` field is tagged as `secret`. The log function respects this flag by masking
-the field value when logging it in order not to reveal sensitive information. 
+the field value when logging it in order not to reveal sensitive information.
 
 By setting the prefix to an empty string, you can disable the name prefix completely.
 
@@ -119,16 +118,16 @@ By setting the prefix to an empty string, you can disable the name prefix comple
 ### Data Parsing Rules
 
 Because the values of environment variables are strings, if the corresponding struct fields are of different types,
-go-env will convert the string values into appropriate types before assigning them to the struct fields. 
+go-env will convert the string values into appropriate types before assigning them to the struct fields.
 
 - If a struct contains embedded structs, the fields of the embedded structs will be populated like they are directly
-under the containing struct. 
+under the containing struct.
 
 - If a struct field type implements `env.Setter`, `env.TextMarshaler`, or `env.BinaryMarshaler` interface,
 the corresponding interface method will be used to load a string value into the field.
 
 - If a struct field is of a primary type, such as `int`, `string`, `bool`, etc., a string value will be parsed
-accordingly and assigned to the field. For example, the string value `TRUE` can be parsed correctly into a 
+accordingly and assigned to the field. For example, the string value `TRUE` can be parsed correctly into a
 boolean `true` value, while `TrUE` will cause a parsing error.
 
 - If a struct field is of a complex type, such as map, slice, struct, the string value will be treated as a JSON

--- a/env.go
+++ b/env.go
@@ -46,7 +46,7 @@ var (
 	// TagName specifies the tag name for customizing struct field names when loading environment variables
 	TagName = "env"
 
-	// nameRegex is used to convert a string from camelCase into snake format
+	// nameRegex is used to convert a string from camelCase into snake case format
 	nameRegex = regexp.MustCompile(`([^A-Z_])([A-Z])`)
 	// loader is the default loader used by the "Load" function at the package level.
 	loader = New("APP_", log.Printf)
@@ -81,8 +81,8 @@ func Load(structPtr interface{}) error {
 // Load uses the following rules to determine what name should be used to look up the value for a struct field:
 // - If the field has an "env" tag, use the tag value as the name, unless the tag is "-" in which case it means
 //   the field should be skipped.
-// - If the field has no "env" tag, turn the field name into snake format and use that as the name.
-// - Names are turned into upper case and prefixed with the specified prefix.
+// - If the field has no "env" tag, turn the field name into UPPER_SNAKE_CASE format and use that as the name.
+// - Names are prefixed with the specified prefix.
 //
 // The following types of struct fields are supported:
 // - types implementing Setter, TextUnmarshaler, BinaryUnmarshaler: the corresponding interface method will be used
@@ -128,7 +128,7 @@ func (l *Loader) Load(structPtr interface{}) error {
 			continue
 		}
 
-		name = l.prefix + strings.ToUpper(name)
+		name = l.prefix + name
 
 		if value, ok := l.lookup(name); ok {
 			logValue := value
@@ -168,14 +168,14 @@ func getName(tag string, field string) (string, bool) {
 	secret := nameLen < len(tag)
 
 	if nameLen == 0 {
-		name = camelCaseToSnake(field)
+		name = camelCaseToUpperSnakeCase(field)
 	}
 	return name, secret
 }
 
-// camelCaseToSnake converts a name from camelCase format into snake format.
-func camelCaseToSnake(name string) string {
-	return nameRegex.ReplaceAllString(name, "${1}_$2")
+// camelCaseToUpperSnakeCase converts a name from camelCase format into UPPER_SNAKE_CASE format.
+func camelCaseToUpperSnakeCase(name string) string {
+	return strings.ToUpper(nameRegex.ReplaceAllString(name, "${1}_$2"))
 }
 
 // setValue assigns a string value to a reflection value using appropriate string parsing and conversion logic.

--- a/env.go
+++ b/env.go
@@ -161,14 +161,16 @@ func indirect(v reflect.Value) reflect.Value {
 
 // getName generates the environment variable name from a struct field tag and the field name.
 func getName(tag string, field string) (string, bool) {
-	secret := false
-	if idx := strings.Index(tag, ","); idx != -1 {
-		tag, secret = tag[:idx], tag[idx+1:] == "secret"
+	name := strings.TrimSuffix(tag, ",secret")
+	nameLen := len(name)
+
+	// If the `,secret` suffix was found, it would have been trimmed, so the length should be different.
+	secret := nameLen < len(tag)
+
+	if nameLen == 0 {
+		name = camelCaseToSnake(field)
 	}
-	if tag == "" {
-		return camelCaseToSnake(field), secret
-	}
-	return tag, secret
+	return name, secret
 }
 
 // camelCaseToSnake converts a name from camelCase format into snake format.

--- a/env_test.go
+++ b/env_test.go
@@ -126,24 +126,24 @@ func Test_setValue(t *testing.T) {
 	}
 }
 
-func Test_camelCaseToSnake(t *testing.T) {
+func Test_camelCaseToUpperSnakeCase(t *testing.T) {
 	tests := []struct {
 		tag      string
 		input    string
 		expected string
 	}{
-		{"t1", "test", "test"},
-		{"t2", "MyName", "My_Name"},
-		{"t3", "My2Name", "My2_Name"},
-		{"t4", "MyID", "My_ID"},
-		{"t5", "My_Name", "My_Name"},
-		{"t6", "MyFullName", "My_Full_Name"},
-		{"t7", "URLName", "URLName"},
-		{"t8", "MyURLName", "My_URLName"},
+		{"t1", "test", "TEST"},
+		{"t2", "MyName", "MY_NAME"},
+		{"t3", "My2Name", "MY2_NAME"},
+		{"t4", "MyID", "MY_ID"},
+		{"t5", "My_Name", "MY_NAME"},
+		{"t6", "MyFullName", "MY_FULL_NAME"},
+		{"t7", "URLName", "URLNAME"},
+		{"t8", "MyURLName", "MY_URLNAME"},
 	}
 
 	for _, test := range tests {
-		output := camelCaseToSnake(test.input)
+		output := camelCaseToUpperSnakeCase(test.input)
 		assert.Equal(t, test.expected, output, test.tag)
 	}
 }
@@ -156,11 +156,11 @@ func Test_getName(t *testing.T) {
 		name   string
 		secret bool
 	}{
-		{"t1", "", "Name", "Name", false},
-		{"t2", "", "MyName", "My_Name", false},
+		{"t1", "", "Name", "NAME", false},
+		{"t2", "", "MyName", "MY_NAME", false},
 		{"t3", "NaME", "Name", "NaME", false},
 		{"t4", "NaME,secret", "Name", "NaME", true},
-		{"t5", ",secret", "Name", "Name", true},
+		{"t5", ",secret", "Name", "NAME", true},
 		{"t6", "NameWith,Comma", "Name", "NameWith,Comma", false},
 		{"t7", "NameWith,Comma,secret", "Name", "NameWith,Comma", true},
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -6,11 +6,12 @@ package env
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_indirect(t *testing.T) {
@@ -160,7 +161,8 @@ func Test_getName(t *testing.T) {
 		{"t3", "NaME", "Name", "NaME", false},
 		{"t4", "NaME,secret", "Name", "NaME", true},
 		{"t5", ",secret", "Name", "Name", true},
-		{"t6", "NaME,", "Name", "NaME", false},
+		{"t6", "NameWith,Comma", "Name", "NameWith,Comma", false},
+		{"t7", "NameWith,Comma,secret", "Name", "NameWith,Comma", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Commit 1: support environment variable names that contain commas

From [The Open Group specification](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html):
> These strings have the form `name=value`; `names` shall not contain the character `’='`. For values to be portable across systems conforming to POSIX.1-2017, the value shall be composed of characters from the portable character set (except NUL and as indicated below).

TL;DR Commas are valid.

# Commit 2: make it clearer that the name generation uses UPPER_SNAKE_CASE

The documentation (and the code/tests) misled me into thinking that the name generation used Sentence_Snake_Case because it includes examples such as `HostName`→`Host_Name` and `MyURL`→`My_URL`. Even though the next bullet point says the name will be transformed to upper case, I think it is clearer to communicate that in the examples themselves.