### PR TITLE
Require fields to be present if not tagged with `optional`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/qiangxue/go-env"
 	"os"
+
+	"github.com/qiangxue/go-env"
 )
 
 type Config struct {
-	Host string
-	Port int
+	Host     string
+	Port     int
+	Password string `env:",optional"`
 }
 
 func main() {
@@ -53,11 +55,17 @@ func main() {
 	}
 	fmt.Println(cfg.Host)
 	fmt.Println(cfg.Port)
+	fmt.Println(cfg.Password)
 	// Output:
 	// 127.0.0.1
 	// 8080
+	//
 }
 ```
+
+In the above code, the `Password` field is tagged as `optional` whereas the other fields are untagged.
+If a field is not tagged as `optional`, it is a required field, so `env.Load()` will return an error if
+the corresponding environment variable is missing.
 
 ### Environment Variable Names
 
@@ -78,9 +86,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/qiangxue/go-env"
 	"log"
 	"os"
+
+	"github.com/qiangxue/go-env"
 )
 
 type Config struct {

--- a/example_test.go
+++ b/example_test.go
@@ -2,15 +2,16 @@ package env_test
 
 import (
 	"fmt"
-	"github.com/qiangxue/go-env"
 	"log"
 	"os"
+
+	"github.com/qiangxue/go-env"
 )
 
 type Config struct {
 	Host     string
 	Port     int
-	Password string `env:",secret"`
+	Password string `env:",optional,secret"`
 }
 
 func Example_one() {
@@ -23,9 +24,11 @@ func Example_one() {
 	}
 	fmt.Println(cfg.Host)
 	fmt.Println(cfg.Port)
+	fmt.Println(cfg.Password)
 	// Output:
 	// 127.0.0.1
 	// 8080
+	//
 }
 
 func Example_two() {


### PR DESCRIPTION
(Requires major version bump due to default behavior change.)

Currently, fields are optional by default, which means go-env will not return an error if an environment variable is missing. There is also no mechanism to specify that a field should be required. This functionality is important due to the classic Go problem of not being able to distinguish between a default value and a missing value.

The question of whether the default behavior should be optional or required is tricky. For server applications, I think most use cases would want environment variables to be required. For command-line applications, I think most use cases would want environment variables to be optional.

I think requiring a tag for `optional` makes more sense because it pushes the programmer to consider what the default value of the field should be if the environment variable is not set. (For example, a programmer may set a hypothetical `Port` field to `80` if the environment variable is not set.)

Therefore, I have changed the default behavior to be required and I have added a new `optional` option.